### PR TITLE
roll up attention-collector content script

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test:integration": "npm run package && mv web-ext-artifacts/*.zip web-ext-artifacts/study.xpi && mocha --timeout 30000 \"./tests/integration/*.js\"",
     "watch": "npm-run-all --parallel watch:raw watch:bundled",
     "watch:raw": "npm run build:schema && npm run dev -- -w",
-    "watch:bundled": "npm run build:schema && web-ext run --watch-file dist/background.js --watch-file src/attention-collector.js --watch-file schemas/measurements.1.schema.json"
+    "watch:bundled": "npm run build:schema && web-ext run --watch-file dist/background.js --watch-file dist/content-scripts/attention-collector.js --watch-file schemas/measurements.1.schema.json"
   },
   "jest": {
     "verbose": true,

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -36,5 +36,24 @@ export default (cliArgs) => [
       commonjs(),
     ],
   },
+  {
+    input: "src/content-scripts/attention-collector.js",
+    output: {
+      file: "dist/content-scripts/attention-collector.js",
+      sourcemap: isDevMode(cliArgs) ? "inline" : false,
+    },
+    plugins: [
+      replace({
+        // In Developer Mode, the study does not submit data and
+        // gracefully handles communication errors with the Core
+        // Add-on.
+        __ENABLE_DEVELOPER_MODE__: isDevMode(cliArgs),
+      }),
+      resolve({
+        browser: true,
+      }),
+      commonjs(),
+    ],
+  }
   // NOTE: a content script rollup is not needed for this study.
 ];

--- a/src/attention-reporter.js
+++ b/src/attention-reporter.js
@@ -156,7 +156,7 @@ export async function startMeasurement({
     registeredContentScript = await browser.contentScripts.register({
         matches: matchPatterns,
         js: [{
-            file: "/src/content-scripts/attention-collector.js"
+            file: "/dist/content-scripts/attention-collector.js"
         }],
         runAt: "document_start"
     });


### PR DESCRIPTION
The `attention-collector` content script is loaded directly from `src/` and not `dist/`, which will not work in the packaged extension.

This change causes us to require a build step (either `npm run dev` or `npm run build`) since trying to load the unpacked extension directly via the browser will not work, but this is pretty normal in my experience. `npm run watch` is more convenient than manually loading an unpacked dir anyway.