### PR TITLE
removes `canonicalOrOGURL` from the code and schema

### DIFF
--- a/STUDY_QA.md
+++ b/STUDY_QA.md
@@ -33,7 +33,6 @@ We will use only the `debug` and `error` views here. These appear below the tras
 ```javascript
 {
   "pageId": "59aad732a2bb6b3b9efbe80813711475",
-  "canonicalOrOGURL": "",
   "origin": "https://www.wikipedia.org",
   "referrerOrigin": "",
   "pageVisitStartTime": 1617401158259,
@@ -60,7 +59,6 @@ We will use only the `debug` and `error` views here. These appear below the tras
 ```javascript
 {
   "pageId": "9341e4dc5d35d6ac26687193be2c6535",
-  "canonicalOrOGURL": "https://www.youtube.com/",
   "origin": "https://www.youtube.com",
   "referrerOrigin": "",
   "pageVisitStartTime": 1617135199869,
@@ -82,7 +80,6 @@ We will use only the `debug` and `error` views here. These appear below the tras
 ```javascript
 {
   "pageId": "2e9109c1a64eb6615fa434f418ce6c77",
-  "canonicalOrOGURL": "",
   "origin": "https://www.wiktionary.org",
   "referrerOrigin": "https://www.wikipedia.org",
   "pageVisitStartTime": 1617135086813,
@@ -110,7 +107,6 @@ We will use only the `debug` and `error` views here. These appear below the tras
 ```javascript
 {
   "pageId": "f3d3f2d6f5a6f767ab0081d2d1f6dbcc",
-  "canonicalOrOGURL": "https://www.youtube.com/",
   "origin": "https://www.youtube.com",
   "referrerOrigin": "",
   "pageVisitStartTime": 1617135289520,
@@ -136,7 +132,6 @@ We will use only the `debug` and `error` views here. These appear below the tras
 ```javascript
 {
   "pageId": "e196594a6aa7edb7843ae1561945e899",
-  "canonicalOrOGURL": "",
   "origin": "https://www.wikipedia.org",
   "referrerOrigin": "",
   "pageVisitStartTime": 1617135507676,
@@ -171,7 +166,6 @@ Audio events behave somewhat like attention events, with a few special distincti
 ```javascript
 {
   "pageId": "1c46f00f3b759b610eed697b2ed5ab7c",
-  "canonicalOrOGURL": "https://www.youtube.com/",
   "origin": "https://www.youtube.com",
   "referrerOrigin": "",
   "pageVisitStartTime": 1617401335251,
@@ -194,7 +188,6 @@ Audio events behave somewhat like attention events, with a few special distincti
 ```javascript
 {
   "pageId": "1c46f00f3b759b610eed697b2ed5ab7c",
-  "canonicalOrOGURL": "https://www.youtube.com/",
   "origin": "https://www.youtube.com",
   "referrerOrigin": "",
   "pageVisitStartTime": 1617401335251,

--- a/schemas/measurements.1.schema.json
+++ b/schemas/measurements.1.schema.json
@@ -19,15 +19,14 @@
         "eventType": {
           "type": "string",
           "description": "the type of event this object represents",
-          "enum": ["attention", "audio"]
+          "enum": [
+            "attention",
+            "audio"
+          ]
         },
         "pageId": {
           "type": "string",
           "description": "each page ID is 128-bit value, randomly generated with the Web Crypto API and stored as a hexadecimal `String`. While this representation is less efficient than a `Uint8Array` or similar, it is more convenient for development and debugging. The page ID is available in the content script environment."
-        },
-        "canonicalOrOGURL": {
-          "type": "string",
-          "description": "The canonical URL as found in the the page's head element (e.g. <link rel='canonical' href='...' />). If the canonical URL isn't present, looks for and uses the og:url tag contents. if neither are present, will be an empty string."
         },
         "origin": {
           "type": "string",

--- a/schemas/measurements.config.mjs
+++ b/schemas/measurements.config.mjs
@@ -8,10 +8,6 @@ export const sharedEventProperties = {
         "type": "string",
         "description": "each page ID is 128-bit value, randomly generated with the Web Crypto API and stored as a hexadecimal `String`. While this representation is less efficient than a `Uint8Array` or similar, it is more convenient for development and debugging. The page ID is available in the content script environment."
       },
-      "canonicalOrOGURL": {
-        "type": "string",
-        "description": "The canonical URL as found in the the page's head element (e.g. <link rel='canonical' href='...' />). If the canonical URL isn't present, looks for and uses the og:url tag contents. if neither are present, will be an empty string."
-      },
       "origin": {
         "type": "string",
         "description": "the origin of the URL associated with the page visit. Calculated by applying new URL(url).origin. See https://developer.mozilla.org/en-US/docs/Web/API/URL/origin"

--- a/src/attention-reporter.js
+++ b/src/attention-reporter.js
@@ -35,9 +35,6 @@ import * as PageManager from "../WebScience/Utilities/PageManager.js";
  * @typedef {Object} UserEvent
  * 
  * @property {string} pageId - The ID for the page, unique across browsing sessions.
- * @property {string} canonicalOrOGURL - The canonical URL as found in the the page's head element
- * (e.g. <link rel="canonical" href="..." />). If the canonical URL isn't present,
- * looks for and uses the og:url tag contents. if neither are present, will be an empty string.
  * @property {string} origin – the origin of the URL associated with the page visit. Calculated by applying new URL(url).origin.
  * See https://developer.mozilla.org/en-US/docs/Web/API/URL/origin
  * @property {string} referrerOrigin - The origin of the referrer URL for the page loading in the tab, or `""` if
@@ -47,7 +44,7 @@ import * as PageManager from "../WebScience/Utilities/PageManager.js";
  * @property {number} duration - Time in miliseconds that the event lasted.
  * @property {string} reason - the reason the attention event ended.
  * @property {string} title - the page's <title> contents, taken from the <head> tag.
- * @property {string} ogDescription - the page's og:description <meta> tag, taken from the <head> tag.
+ * @property {string} description - the page's og:description <meta> tag, taken from the <head> tag.
  * @property {string} ogType - the page's og:type <meta> tag, taken from the <head> tag.
  * @property {number} eventStartTime - a unix timestamp in miliseconds specifying the start time of the event
  * @property {number} eventStopTime - a unix timestamp in miliseconds specifying the stop time of the event
@@ -169,7 +166,6 @@ export async function startMeasurement({
     // Event properties that both of these event types consume.
     const sharedEventProperties = {
         pageId: "string",
-        canonicalOrOGURL: "string",
         origin: "string",
         referrerOrigin: "string",
         eventType: "string",

--- a/src/content-scripts/attention-collector.js
+++ b/src/content-scripts/attention-collector.js
@@ -142,12 +142,6 @@
          */
         let ogType = "";
 
-        /**
-         * The canonical url or og:url tags in the page's head.
-         * @type {string}
-         */
-        let canonicalOrOGURL = "";
-
         /** 
          * The start time (unix timestamp in ms) the attention event started.
          * @type {number}
@@ -201,25 +195,6 @@
         /**
          * 
          * @param {*} documentElement 
-         * @returns {string} the href of the canonical url link element, if present
-         */
-        function getCanonicalURL(documentElement) {
-            const elem = documentElement.querySelector("link[rel='canonical']");
-            return elem === null ? undefined : elem.href;
-        }
-
-        /**
-         * 
-         * @param {*} documentElement 
-         * @returns {string} the contents of the og:url meta element, if present
-         */
-        function getOGURL(documentElement) {
-            return getContentsHavingSelector("meta[property='og:url']", documentElement);
-        }
-
-        /**
-         * 
-         * @param {*} documentElement 
          * @returns {string} the content of the meta og:description tag
          */
         function getOGDescription(documentElement) {
@@ -241,7 +216,6 @@
             title = getTitle(document) || "";
             ogDescription = getOGDescription(document) || getMetaDescription(document) || "";
             ogType = getOGType(document) || "";
-            canonicalOrOGURL = getCanonicalURL(document) || getOGURL(document) || "";
         }
 
         function getOrigin(url) {
@@ -263,7 +237,6 @@
             PageManager.sendMessage({ 
                 type: "RS01.attentionCollection",
                 pageId: PageManager.pageId,
-                canonicalOrOGURL,
                 origin: getOrigin(PageManager.url),
                 referrerOrigin: getOrigin(PageManager.referrer),
                 pageVisitStartTime: PageManager.pageVisitStartTime,
@@ -291,7 +264,6 @@
             PageManager.sendMessage({ 
                 type: "RS01.audioCollection",
                 pageId: PageManager.pageId,
-                canonicalOrOGURL,
                 origin: getOrigin(PageManager.url),
                 referrerOrigin: getOrigin(PageManager.referrer),
                 pageVisitStartTime: PageManager.pageVisitStartTime,


### PR DESCRIPTION
We decided to remove the canonical url field from this study. This PR takes care of that.