### PR TITLE
changes RS01.event to measurement in the `payloadType` (aka `schemaName`) study.js

### DIFF
--- a/src/study.js
+++ b/src/study.js
@@ -11,7 +11,7 @@ function collectEventDataAndSubmit(rally, devMode) {
     // we send the payload using one schema, "RS01.event".
     // Once https://github.com/mozilla-rally/web-science/issues/33 is resolved,
     // we will change the collection schema (but keep this pipeline schema the same).
-    rally.sendPing("RS01.event", data);
+    rally.sendPing("measurement", data);
   }, {
       matchPatterns: ["<all_urls>"],
       privateWindows: false


### PR DESCRIPTION
This is a launch-blocking change. After reading through all the code, it appears taht we were not sending to the correct `schemaName`. We should change `payloadType` to `schemaName` in rally.js to clarify this since this one semantic change almost caused us to ship a whole schema that was wrong.