### PR TITLE
generate glean files as js, and ensure `npm run dev` builds glean first

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "test:unit": "jest",
     "test:integration": "npm run package && mv web-ext-artifacts/*.zip web-ext-artifacts/study.xpi && mocha --timeout 30000 \"./tests/integration/*.js\"",
     "dev": "npm-run-all --parallel dev:raw dev:bundled",
-    "dev:raw": "npm run build:schema && rollup -c --config-enable-developer-mode -w",
-    "dev:bundled": "npm run build:schema && web-ext run --target chromium --watch-file dist/background.js --watch-file dist/content-scripts/attention-collector.js --watch-file schemas/measurements.1.schema.json"
+    "dev:raw": "npm run build:glean && npm run build:schema && rollup -c --config-enable-developer-mode -w",
+    "dev:bundled": "npm run build:glean && npm run build:schema && web-ext run --target chromium --watch-file dist/background.js --watch-file dist/content-scripts/attention-collector.js --watch-file schemas/measurements.1.schema.json"
   },
   "jest": {
     "verbose": true,

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "build": "npm run build:schema && npm run build:addon",
     "build:addon": "npm run build:glean && rollup -c && web-ext build --overwrite-dest",
     "build:glean": "npm run build:glean:metrics && npm run build:glean:docs",
-    "build:glean:metrics": "glean translate ./metrics.yaml ./pings.yaml -f typescript -o src/generated",
+    "build:glean:metrics": "glean translate ./metrics.yaml ./pings.yaml -f javascript -o src/generated",
     "build:glean:docs": "glean translate ./metrics.yaml ./pings.yaml -f markdown -o docs",
     "build:schema": "node schemas/generate-schema.mjs",
     "build:storybook": "build-storybook -s ./",


### PR DESCRIPTION
Closes issue #126